### PR TITLE
Product API 작성하기

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,46 +1,10 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
 import validationSchema from './config/validationScheme';
-// import { StoreModule } from './store/store.module';
-import { ProductModule } from './product/product.module';
-import { ReceiptModule } from './receipt/receipt.module';
-import { ReceiptByProductModule } from './receipt-by-product/receipt-by-product.module';
 import { MySQLModule } from './config/mysql/mysql.module';
 import { StoreModule } from './domain/store/store.module';
 import { CategoryModule } from './domain/category/category.module';
-
-// @Module({
-//   imports: [
-//     ConfigModule.forRoot({
-//       isGlobal: true,
-//       envFilePath: '.env',
-//       validationSchema,
-//     }),
-//     TypeOrmModule.forRootAsync({
-//       imports: [ConfigModule],
-//       useFactory: (configService: ConfigService) => ({
-//         type: 'mysql',
-//         host: configService.get('DATABASE_HOST'),
-//         port: configService.get<number>('DATABASE_PORT'),
-//         username: configService.get('DATABASE_USERNAME'),
-//         password: configService.get('DATABASE_PASSWORD'),
-//         database: configService.get('DATABASE_DATABASE'),
-//         entities: [],
-//         autoLoadEntities: true,
-//         synchronize: true,
-//         logging: true,
-//       }),
-//       inject: [ConfigService],
-//     }),
-//     StoreModule,
-//     CategoryModule,
-//     ProductModule,
-//     ReceiptModule,
-//     ReceiptByProductModule,
-//   ],
-// })
-// export class AppModule {}
+import { ProductModule } from './domain/product/product.module';
 
 @Module({
   imports: [
@@ -52,6 +16,7 @@ import { CategoryModule } from './domain/category/category.module';
     MySQLModule,
     StoreModule,
     CategoryModule,
+    ProductModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/domain/category/category.service.ts
+++ b/backend/src/domain/category/category.service.ts
@@ -37,7 +37,7 @@ export class CategoryService implements OnModuleInit {
     try {
       const [rows] = await this.promisePool.execute(`
         INSERT INTO CATEGORY (${Object.keys(category).join()})
-        VALUES (${Object.values(category).map(format.addQuotesToString).join()})
+        VALUES (${Object.values(category).map(format.formatData).join()})
       `);
 
       return rows.insertId;
@@ -49,7 +49,7 @@ export class CategoryService implements OnModuleInit {
   async updateCategoryById(id: number, category: categoryUpdateType) {
     try {
       const options = Object.entries(category)
-        .map(([key, value]) => `${key} = ${format.addQuotesToString(value)}`)
+        .map(([key, value]) => `${key} = ${format.formatData(value)}`)
         .join();
 
       const [rows] = await this.promisePool.execute(`

--- a/backend/src/domain/product/product.controller.ts
+++ b/backend/src/domain/product/product.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { ProductService } from './product.service';
+
+@Controller('product')
+export class ProductController {
+  constructor(private readonly productService: ProductService) {}
+}

--- a/backend/src/domain/product/product.controller.ts
+++ b/backend/src/domain/product/product.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Post } from '@nestjs/common';
 import { ProductService } from './product.service';
 import { productCreateType } from './product.type';
 
@@ -11,5 +11,12 @@ export class ProductController {
     await this.productService.createProduct(product);
 
     return 'created';
+  }
+
+  @Delete(':id')
+  async deleteProductById(@Param('id') id: number) {
+    await this.productService.deleteProductById(id);
+
+    return 'deleted';
   }
 }

--- a/backend/src/domain/product/product.controller.ts
+++ b/backend/src/domain/product/product.controller.ts
@@ -1,7 +1,15 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Post } from '@nestjs/common';
 import { ProductService } from './product.service';
+import { productCreateType } from './product.type';
 
 @Controller('product')
 export class ProductController {
   constructor(private readonly productService: ProductService) {}
+
+  @Post()
+  async createProduct(@Body() product: productCreateType) {
+    await this.productService.createProduct(product);
+
+    return 'created';
+  }
 }

--- a/backend/src/domain/product/product.controller.ts
+++ b/backend/src/domain/product/product.controller.ts
@@ -1,10 +1,23 @@
-import { Body, Controller, Delete, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { ProductService } from './product.service';
 import { productCreateType } from './product.type';
 
 @Controller('product')
 export class ProductController {
   constructor(private readonly productService: ProductService) {}
+
+  @Get()
+  async getProductByCategoryId(@Query('categoryId') categoryId: number) {
+    return await this.productService.getProductByCategoryId(categoryId);
+  }
 
   @Post()
   async createProduct(@Body() product: productCreateType) {

--- a/backend/src/domain/product/product.controller.ts
+++ b/backend/src/domain/product/product.controller.ts
@@ -4,11 +4,12 @@ import {
   Delete,
   Get,
   Param,
+  Patch,
   Post,
   Query,
 } from '@nestjs/common';
 import { ProductService } from './product.service';
-import { productCreateType } from './product.type';
+import { productCreateType, productUpdateType } from './product.type';
 
 @Controller('product')
 export class ProductController {
@@ -24,6 +25,16 @@ export class ProductController {
     await this.productService.createProduct(product);
 
     return 'created';
+  }
+
+  @Patch(':id')
+  async updateProductById(
+    @Param('id') id: number,
+    @Body() product: productUpdateType,
+  ) {
+    await this.productService.updateProductById(id, product);
+
+    return 'updated';
   }
 
   @Delete(':id')

--- a/backend/src/domain/product/product.module.ts
+++ b/backend/src/domain/product/product.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { MySQLModule } from 'src/config/mysql/mysql.module';
+import { ProductController } from './product.controller';
+import { ProductService } from './product.service';
+
+@Module({
+  imports: [MySQLModule],
+  providers: [ProductService],
+  controllers: [ProductController],
+})
+export class ProductModule {}

--- a/backend/src/domain/product/product.service.ts
+++ b/backend/src/domain/product/product.service.ts
@@ -38,4 +38,17 @@ export class ProductService implements OnModuleInit {
       console.error(e);
     }
   }
+
+  async deleteProductById(id: number) {
+    try {
+      const [rows] = await this.promisePool.execute(`
+        DELETE FROM PRODUCT
+        WHERE id = ${id}
+      `);
+
+      return rows;
+    } catch (e) {
+      console.error(e);
+    }
+  }
 }

--- a/backend/src/domain/product/product.service.ts
+++ b/backend/src/domain/product/product.service.ts
@@ -26,6 +26,17 @@ export class ProductService implements OnModuleInit {
     `);
   }
 
+  async getProductByCategoryId(categoryId: number) {
+    try {
+      const [rows] = await this.promisePool.execute(`SELECT * FROM PRODUCT
+      WHERE categoryId = ${categoryId}`);
+
+      return rows;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
   async createProduct(product: productCreateType) {
     try {
       const [rows] = await this.promisePool.execute(`

--- a/backend/src/domain/product/product.service.ts
+++ b/backend/src/domain/product/product.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { MySQLService } from 'src/config/mysql/mysql.service';
+
+@Injectable()
+export class ProductService implements OnModuleInit {
+  promisePool: any;
+  constructor(private mysqlService: MySQLService) {
+    this.promisePool = this.mysqlService.pool.promise();
+  }
+  async onModuleInit() {
+    await this.promisePool.execute(`
+      CREATE TABLE IF NOT EXISTS PRODUCT (
+        id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        name VARCHAR(20) NOT NULL,
+        price DECIMAL(10, 0) NOT NULL,
+        categoryId INT,
+        productOption json,
+        thumbnail VARCHAR(255),
+        isPopular BOOLEAN,
+        isSoldOut BOOLEAN,
+        deletedAt DATETIME,
+        FOREIGN KEY (categoryId) REFERENCES CATEGORY(id)
+      )
+    `);
+  }
+}

--- a/backend/src/domain/product/product.service.ts
+++ b/backend/src/domain/product/product.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { MySQLService } from 'src/config/mysql/mysql.service';
+import format from '../utils/format';
+import { productCreateType } from './product.type';
 
 @Injectable()
 export class ProductService implements OnModuleInit {
@@ -22,5 +24,18 @@ export class ProductService implements OnModuleInit {
         FOREIGN KEY (categoryId) REFERENCES CATEGORY(id)
       )
     `);
+  }
+
+  async createProduct(product: productCreateType) {
+    try {
+      const [rows] = await this.promisePool.execute(`
+        INSERT INTO PRODUCT (${Object.keys(product).join()})
+        VALUES (${Object.values(product).map(format.formatData).join()})
+      `);
+
+      return rows.insertId;
+    } catch (e) {
+      console.error(e);
+    }
   }
 }

--- a/backend/src/domain/product/product.service.ts
+++ b/backend/src/domain/product/product.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { MySQLService } from 'src/config/mysql/mysql.service';
 import format from '../utils/format';
-import { productCreateType } from './product.type';
+import { productCreateType, productUpdateType } from './product.type';
 
 @Injectable()
 export class ProductService implements OnModuleInit {
@@ -45,6 +45,23 @@ export class ProductService implements OnModuleInit {
       `);
 
       return rows.insertId;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  async updateProductById(id: number, product: productUpdateType) {
+    try {
+      const options = Object.entries(product)
+        .map(([key, value]) => `${key} = ${format.formatData(value)}`)
+        .join();
+
+      const [rows] = await this.promisePool.execute(`
+        UPDATE PRODUCT SET ${options} 
+        WHERE id = ${id}
+        `);
+
+      return rows;
     } catch (e) {
       console.error(e);
     }

--- a/backend/src/domain/product/product.type.ts
+++ b/backend/src/domain/product/product.type.ts
@@ -1,0 +1,16 @@
+export interface productCreateType {
+  name: string;
+  price: number;
+  categoryId: number;
+  productOption?: JSON;
+  thumbnail?: string;
+}
+
+export interface productUpdateType {
+  name?: string;
+  price?: number;
+  productOption?: JSON;
+  thumbnail?: string;
+  isPopular?: boolean;
+  isSoldOut?: boolean;
+}

--- a/backend/src/domain/store/store.service.ts
+++ b/backend/src/domain/store/store.service.ts
@@ -26,7 +26,7 @@ export class StoreService implements OnModuleInit {
     try {
       const [rows] = await this.promisePool.execute(`
         INSERT INTO STORE (${Object.keys(store).join()})
-        VALUES (${Object.values(store).map(format.addQuotesToString).join()})
+        VALUES (${Object.values(store).map(format.formatData).join()})
       `);
 
       return rows.insertId;
@@ -50,7 +50,7 @@ export class StoreService implements OnModuleInit {
   async updateById(id: number, store: storeUpdateType) {
     try {
       const options = Object.entries(store)
-        .map(([key, value]) => `${key} = ${format.addQuotesToString(value)}`)
+        .map(([key, value]) => `${key} = ${format.formatData(value)}`)
         .join();
 
       const [rows] = await this.promisePool.execute(`

--- a/backend/src/domain/utils/format.ts
+++ b/backend/src/domain/utils/format.ts
@@ -6,6 +6,19 @@ function addQuotesToString(value) {
   return isString(value) ? `"${value}"` : value;
 }
 
+function formatData(value) {
+  const type = typeof value;
+
+  switch (type) {
+    case 'string':
+      return addQuotesToString(value);
+    case 'object':
+      return `'${JSON.stringify(value)}'`;
+    default:
+      return value;
+  }
+}
+
 export default {
-  addQuotesToString,
+  formatData,
 };


### PR DESCRIPTION
# 📑 개요
Product API 작성하기

# 📎 관련 이슈
#17 

# 💬 작업 내용
Product 관련 CRUD 구현

# 🚧 PR 특이 사항
Closes #17 

# 🌡 실제 소요 시간
1h

# 🎁 어려웠던 점
JSON 타입을 넣으려고 하는데 option 자체가 SQL 예약어여서 에러가 계속 발생했다.
-> productOption으로 변경함
Object 타입 데이터를 DB에 넣기 위해 stringify 메소드를 한번 거쳐야했다. 하지만 내부 키, 벨류가 쌍따옴표로 묶이기 때문에 바깥까지 쌍따옴표로 묶으면 parse에러가 발생한다.
-> Single Quote로 묶고 stringify하는 유틸 메소드 추가