### PR TITLE
키오스크 메인 페이지 마크업

### DIFF
--- a/backend/src/domain/store/store.controller.ts
+++ b/backend/src/domain/store/store.controller.ts
@@ -48,6 +48,13 @@ export class StoreController {
     return res;
   }
 
+  @Post('checkPassword')
+  async checkPasswordByStoreId(@Body() store: storeLoginType) {
+    const res = await this.storeService.checkPasswordByStoreId(store);
+
+    return res;
+  }
+
   @Patch(':id')
   async updateById(@Param('id') id: number, @Body() store: storeUpdateType) {
     await this.storeService.updateById(id, store);

--- a/backend/src/domain/store/store.service.ts
+++ b/backend/src/domain/store/store.service.ts
@@ -81,4 +81,18 @@ export class StoreService {
       console.error(e);
     }
   }
+
+  async checkPasswordByStoreId(store: storeLoginType) {
+    const { storeId, password } = store;
+    try {
+      const [rows] = await this.promisePool.execute(`SELECT count(*) FROM STORE
+      WHERE storeId = ${format.formatData(
+        storeId,
+      )} AND password = ${format.formatData(password)}`);
+
+      return rows[0]['count(*)'];
+    } catch (e) {
+      console.error(e);
+    }
+  }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react';
 import Admin from './pages/Admin/Admin';
-import CustomerOrder from './pages/CustomerOrder';
+import CustomerOrder from './pages/Customer/CustomerOrder';
 import Entrance from './pages/Entrance/Entrance';
 import GlobalStyle from './styles/global';
 import { Routes, Route } from './lib/Router';
@@ -29,7 +29,7 @@ function App() {
       <GlobalStyle />
       <Routes>
         <Route path="/admin" element={<Admin />} />
-        <Route path="/customer" element={<CustomerOrder />} />
+        <Route path="/customer-order" element={<CustomerOrder />} />
         <Route path="/" element={<Entrance />} />
       </Routes>
     </>

--- a/frontend/src/api/storeAPI.ts
+++ b/frontend/src/api/storeAPI.ts
@@ -1,20 +1,26 @@
 import { StoreLoginType, StoreRegisterType, StoreType } from '../types/store';
 import client from './client';
 
-export async function login(store: StoreLoginType): Promise<StoreType> {
+async function login(store: StoreLoginType): Promise<StoreType> {
   const { data } = await client.post('/store/login', store);
 
   return data;
 }
 
-export async function register(store: StoreRegisterType): Promise<StoreType> {
+async function register(store: StoreRegisterType): Promise<StoreType> {
   const { data } = await client.post('/store/register', store);
 
   return data;
 }
 
-export async function getStoreInfo(id: number): Promise<StoreType> {
+async function getStoreInfo(id: number): Promise<StoreType> {
   const { data } = await client.get(`/store/${id}`);
+
+  return data;
+}
+
+async function checkStorePassword(store: StoreLoginType) {
+  const { data } = await client.post(`/store/checkPassword`, store);
 
   return data;
 }
@@ -23,4 +29,5 @@ export default {
   login,
   register,
   getStoreInfo,
+  checkStorePassword,
 };

--- a/frontend/src/components/HOC/withCheckAdmin.tsx
+++ b/frontend/src/components/HOC/withCheckAdmin.tsx
@@ -1,0 +1,16 @@
+import React, { useContext } from 'react';
+import { adminAuthorityContext } from '../../context/AdminAuthorityProvider';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function withCheckAdmin(Component: React.ComponentType<any>) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return function WithCheckAdmin(props: any) {
+    const { adminAuthority } = useContext(adminAuthorityContext);
+
+    if (!adminAuthority) return <></>;
+
+    return <Component {...props} />;
+  };
+}
+
+export default withCheckAdmin;

--- a/frontend/src/components/Header/Header.style.ts
+++ b/frontend/src/components/Header/Header.style.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import color from '../../styles/variables/color';
 
 export const StyledHeader = styled.header`
   background: #1e2222;
@@ -8,5 +9,18 @@ export const StyledHeader = styled.header`
 
   h1 {
     margin-bottom: 1rem;
+  }
+
+  .header-btns {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+    flex-direction: column;
+    button {
+      background-color: ${color.white};
+      padding: 0.25rem;
+      margin-bottom: 1rem;
+    }
   }
 `;

--- a/frontend/src/components/Modal/CategoryModal/CategoryAddModalTrigger.tsx
+++ b/frontend/src/components/Modal/CategoryModal/CategoryAddModalTrigger.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { storeContext } from '../../../context/StoreProvider';
 import { CategoryType } from '../../../types/category';
+import withCheckAdmin from '../../HOC/withCheckAdmin';
 import { useModal } from '../hooks';
 import Modal from '../Modal';
 import CategoryAddModal from './CategoryAddModal';
@@ -29,4 +30,4 @@ function CategoryAddModalTrigger({ setCategory }: Props) {
   );
 }
 
-export default CategoryAddModalTrigger;
+export default withCheckAdmin(CategoryAddModalTrigger);

--- a/frontend/src/components/Modal/CategoryModal/CategoryDeleteModalTrigger.tsx
+++ b/frontend/src/components/Modal/CategoryModal/CategoryDeleteModalTrigger.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { CategoryType } from '../../../types/category';
+import withCheckAdmin from '../../HOC/withCheckAdmin';
 import { useModal } from '../hooks';
 import Modal from '../Modal';
 import CategoryDeleteModal from './CategoryDeleteModal';
@@ -28,4 +29,4 @@ function CategoryDeleteModalTrigger({ category, setCategory }: Props) {
   );
 }
 
-export default CategoryDeleteModalTrigger;
+export default withCheckAdmin(CategoryDeleteModalTrigger);

--- a/frontend/src/components/Modal/MoveAdminModal/MoveAdminModal.tsx
+++ b/frontend/src/components/Modal/MoveAdminModal/MoveAdminModal.tsx
@@ -1,0 +1,37 @@
+import React, { useContext } from 'react';
+import { storeContext } from '../../../context/StoreProvider';
+import storeAPI from '../../../api/storeAPI';
+import { useNavigate } from '../../../lib/Router';
+
+function MoveAdminModal() {
+  const { store } = useContext(storeContext);
+  const navigate = useNavigate();
+
+  const handleCheckPassword = async (
+    event: React.FormEvent<HTMLFormElement>,
+  ) => {
+    event.preventDefault();
+    const { storePassword } = event.target as HTMLFormElement;
+
+    const result = await storeAPI.checkStorePassword({
+      storeId: store.storeId,
+      password: storePassword.value,
+    });
+
+    if (!result) {
+      return;
+    }
+
+    navigate('/admin');
+  };
+
+  return (
+    <form onSubmit={handleCheckPassword}>
+      <strong>매장의 비밀번호를 입력해주세요.</strong>
+      <input type="password" name="storePassword" />
+      <button type="submit">확인</button>
+    </form>
+  );
+}
+
+export default MoveAdminModal;

--- a/frontend/src/components/Modal/MoveAdminModal/MoveAdminModalTrigger.tsx
+++ b/frontend/src/components/Modal/MoveAdminModal/MoveAdminModalTrigger.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useModal } from '../hooks';
+import Modal from '../Modal';
+import MoveAdminModal from './MoveAdminModal';
+
+function MoveAdminModalTrigger() {
+  const { isModalOpen, openModal, closeModal } = useModal();
+
+  return (
+    <>
+      <button type="button" onClick={openModal}>
+        매장관리
+      </button>
+      <Modal isModalOpen={isModalOpen} closeModal={closeModal}>
+        <MoveAdminModal />
+      </Modal>
+    </>
+  );
+}
+
+export default MoveAdminModalTrigger;

--- a/frontend/src/components/Modal/ProductModal/ProductAddModalTrigger.tsx
+++ b/frontend/src/components/Modal/ProductModal/ProductAddModalTrigger.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ProductType } from '../../../types/product';
+import withCheckAdmin from '../../HOC/withCheckAdmin';
 import { useModal } from '../hooks';
 import Modal from '../Modal';
 import ProductAddModal from './ProductAddModal';
@@ -28,4 +29,4 @@ function ProductAddModalTrigger({ setProduct, categoryId }: Props) {
   );
 }
 
-export default ProductAddModalTrigger;
+export default withCheckAdmin(ProductAddModalTrigger);

--- a/frontend/src/components/Modal/ProductModal/ProductDeleteModalTrigger.tsx
+++ b/frontend/src/components/Modal/ProductModal/ProductDeleteModalTrigger.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ProductType } from '../../../types/product';
+import withCheckAdmin from '../../HOC/withCheckAdmin';
 import { useModal } from '../hooks';
 import Modal from '../Modal';
 import ProductDeleteModal from './ProductDeleteModal';
@@ -28,4 +29,4 @@ function ProductDeleteModalTrigger({ setProduct, product }: Props) {
   );
 }
 
-export default ProductDeleteModalTrigger;
+export default withCheckAdmin(ProductDeleteModalTrigger);

--- a/frontend/src/components/ProductList/ProductItem.tsx
+++ b/frontend/src/components/ProductList/ProductItem.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { adminAuthorityContext } from '../../context/AdminAuthorityProvider';
 import { ProductType } from '../../types/product';
 import ProductDeleteModalTrigger from '../Modal/ProductModal/ProductDeleteModalTrigger';
 import ProductOption from './ProductOption/ProductOption';
@@ -9,16 +10,23 @@ interface ProductItemType {
 }
 
 function ProductItem({ item, setProduct }: ProductItemType) {
+  const { adminAuthority } = useContext(adminAuthorityContext);
+  const handleProductClick = () => {
+    if (adminAuthority) return;
+
+    console.log(item);
+  };
+
   return (
-    <li>
+    <li onClick={handleProductClick}>
       <ProductDeleteModalTrigger setProduct={setProduct} product={item} />
       <div className="extra-info">
         {!!item.isPopular && <span>인기</span>}
         {!!item.isSoldOut && <span>완판</span>}
       </div>
       <img src={item.thumbnail} alt="product_thumbnail" />
-      <div>상품명: {item.name}</div>
-      <div>가격: {item.price}원</div>
+      <div>{item.name}</div>
+      <div>{item.price}원</div>
       <ProductOption options={item.productOption} id={item.id} />
     </li>
   );

--- a/frontend/src/context/AdminAuthorityProvider.tsx
+++ b/frontend/src/context/AdminAuthorityProvider.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useState } from 'react';
+
+interface AdminAuthorityContextType {
+  adminAuthority: boolean;
+  changeAdminAuthority: (prev: boolean) => void;
+}
+
+export const adminAuthorityContext = createContext<AdminAuthorityContextType>({
+  adminAuthority: false,
+  changeAdminAuthority: () => undefined,
+});
+
+function AdminAuthorityProvider({ children }: { children: React.ReactNode }) {
+  const [adminAuthority, setAdminAuthority] = useState<boolean>(false);
+
+  const adminAuthorityContextValue = {
+    adminAuthority,
+    changeAdminAuthority: setAdminAuthority,
+  };
+
+  return (
+    <adminAuthorityContext.Provider value={adminAuthorityContextValue}>
+      {children}
+    </adminAuthorityContext.Provider>
+  );
+}
+
+export default AdminAuthorityProvider;

--- a/frontend/src/context/ContextProvider.tsx
+++ b/frontend/src/context/ContextProvider.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import AdminAuthorityProvider from './AdminAuthorityProvider';
+import StoreProvider from './StoreProvider';
+
+function ContextProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <StoreProvider>
+      <AdminAuthorityProvider>{children}</AdminAuthorityProvider>
+    </StoreProvider>
+  );
+}
+
+export default ContextProvider;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import StoreProvider from './context/StoreProvider';
+import ContextProvider from './context/ContextProvider';
 import { Router } from './lib/Router';
 
 const root = ReactDOM.createRoot(
@@ -9,8 +9,8 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <Router>
-    <StoreProvider>
+    <ContextProvider>
       <App />
-    </StoreProvider>
+    </ContextProvider>
   </Router>,
 );

--- a/frontend/src/pages/Admin/Admin.tsx
+++ b/frontend/src/pages/Admin/Admin.tsx
@@ -1,8 +1,9 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import CategoryList from '../../components/CategoryList/CategoryList';
 import Header from '../../components/Header/Header';
 import withCheckPermission from '../../components/HOC/withCheckPermission';
 import ProductList from '../../components/ProductList/ProductList';
+import { adminAuthorityContext } from '../../context/AdminAuthorityProvider';
 import { storeContext } from '../../context/StoreProvider';
 import { useNavigate } from '../../lib/Router';
 import { setItemToLocalStorage } from '../../lib/storage';
@@ -13,6 +14,7 @@ function Admin() {
     useCategory();
   const [product, setProduct] = useProduct(selectedCategory);
   const { store } = useContext(storeContext);
+  const { changeAdminAuthority } = useContext(adminAuthorityContext);
   const navigate = useNavigate();
 
   const onLogout = () => {
@@ -23,6 +25,14 @@ function Admin() {
   const openStore = () => {
     navigate('/customer-order');
   };
+
+  useEffect(() => {
+    changeAdminAuthority(true);
+
+    return () => {
+      changeAdminAuthority(false);
+    };
+  }, [changeAdminAuthority]);
 
   return (
     <>

--- a/frontend/src/pages/Customer/CustomerOrder.tsx
+++ b/frontend/src/pages/Customer/CustomerOrder.tsx
@@ -1,43 +1,26 @@
 import React, { useContext } from 'react';
 import CategoryList from '../../components/CategoryList/CategoryList';
 import Header from '../../components/Header/Header';
-import withCheckPermission from '../../components/HOC/withCheckPermission';
+import MoveAdminModalTrigger from '../../components/Modal/MoveAdminModal/MoveAdminModalTrigger';
 import ProductList from '../../components/ProductList/ProductList';
 import { storeContext } from '../../context/StoreProvider';
-import { useNavigate } from '../../lib/Router';
-import { setItemToLocalStorage } from '../../lib/storage';
-import { useCategory, useProduct } from './hooks';
+import { useCategory, useProduct } from '../Admin/hooks';
 
-function Admin() {
+function CustomerOrder() {
   const [category, setCategory, selectedCategory, setSelectedCategory] =
     useCategory();
   const [product, setProduct] = useProduct(selectedCategory);
   const { store } = useContext(storeContext);
-  const navigate = useNavigate();
-
-  const onLogout = () => {
-    setItemToLocalStorage('storeId', '');
-    navigate('/');
-  };
-
-  const openStore = () => {
-    navigate('/customer-order');
-  };
 
   return (
     <>
       <Header>
-        <h1>안녕하세요 사장님.</h1>
+        <h1>어서오세요 고객님.</h1>
         <h2>
           {store.name} {store.branchName}점입니다.
         </h2>
         <div className="header-btns">
-          <button type="button" onClick={openStore}>
-            장사 시작
-          </button>
-          <button type="button" onClick={onLogout}>
-            로그아웃
-          </button>
+          <MoveAdminModalTrigger />
         </div>
       </Header>
       <CategoryList
@@ -55,4 +38,4 @@ function Admin() {
   );
 }
 
-export default withCheckPermission(Admin);
+export default CustomerOrder;

--- a/frontend/src/pages/CustomerOrder.tsx
+++ b/frontend/src/pages/CustomerOrder.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function CustomerOrder() {
-  return <h1>Cumstomer</h1>;
-}
-
-export default CustomerOrder;


### PR DESCRIPTION
# 📑 개요
키오스크 메인 페이지를 마크업한다. 기존의 어드민 페이지를 이용하지만 특정 기능에 대한 접근을 제한한다.

# 📎 관련 이슈
#6 

# 💬 작업 내용
- 현재 접근 권한을 확인하기. context를 통해 권한 상태를 확인한다.
- 권한에 따라 렌더링 여부를 판단하는 고차 컴포넌트 생성

# 🚧 PR 특이 사항
Closes #6 

# 🌡 실제 소요 시간
40m

# 🎁 어려웠던 점
처음에는 localStorage를 이용했었는데, 굳이 브라우저가 종료되도 남아있을 필요가 없는 정보이기 때문에 context로 변경했다. 다양한 컴포넌트에서 계층에 관계없이 접근할 수 있기 때문에 context로 상태를 관리한다.