### PR TITLE
로딩 인디케이터, 카드결제 모달 컴포넌트 구현

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -13,5 +13,6 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <div id="modal"></div>
+    <div id="loading"></div>
   </body>
 </html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,9 +7,12 @@ import { Routes, Route } from './lib/Router';
 import { storeContext } from './context/StoreProvider';
 import storeAPI from './api/storeAPI';
 import { getItemFromLocalStorage } from './lib/storage';
+import Loading from './components/Loading/Loading';
+import { loadingContext } from './context/LoadingProvider';
 
 function App() {
   const { changeStoreInfo } = useContext(storeContext);
+  const { isLoading } = useContext(loadingContext);
 
   useEffect(() => {
     async function setStoreInfo(storeId: number) {
@@ -32,6 +35,7 @@ function App() {
         <Route path="/customer-order" element={<CustomerOrder />} />
         <Route path="/" element={<Entrance />} />
       </Routes>
+      <Loading isLoading={isLoading} />
     </>
   );
 }

--- a/frontend/src/components/Loading/Loading.style.ts
+++ b/frontend/src/components/Loading/Loading.style.ts
@@ -1,0 +1,32 @@
+import styled, { keyframes } from 'styled-components';
+import color from '../../styles/variables/color';
+
+const spinAnimation = keyframes`
+	0% {
+		transform: rotate(0deg);
+	}
+	100% {
+		transform: rotate(1turn);
+}`;
+
+export const LoadingSpinner = styled.div`
+  padding: 2.5rem;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 0.5rem solid ${color.gray};
+  border-top-color: ${color.burgundy};
+  animation: ${spinAnimation} 0.8s linear infinite;
+`;
+
+export const LoadingOverlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/frontend/src/components/Loading/Loading.tsx
+++ b/frontend/src/components/Loading/Loading.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { LoadingOverlay, LoadingSpinner } from './Loading.style';
+import LoadingPortal from './LoadingPortal';
+
+interface Props {
+  isLoading: boolean;
+}
+
+function Loading({ isLoading }: Props) {
+  console.log(isLoading);
+
+  if (!isLoading) return <></>;
+
+  return (
+    <LoadingPortal>
+      <LoadingOverlay>
+        <LoadingSpinner />
+      </LoadingOverlay>
+    </LoadingPortal>
+  );
+}
+
+export default Loading;

--- a/frontend/src/components/Loading/LoadingPortal.tsx
+++ b/frontend/src/components/Loading/LoadingPortal.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+interface LoadingPortalProps {
+  children: React.ReactNode;
+}
+
+function LoadingPortal({ children }: LoadingPortalProps) {
+  const modalElement = document.getElementById('loading') as Element;
+  return ReactDOM.createPortal(children, modalElement);
+}
+
+export default LoadingPortal;

--- a/frontend/src/components/Modal/PaymentModal/CreditCard/CreditCardLoadingModal.tsx
+++ b/frontend/src/components/Modal/PaymentModal/CreditCard/CreditCardLoadingModal.tsx
@@ -1,15 +1,25 @@
-import React from 'react';
+import React, { useContext, useEffect } from 'react';
+import { loadingContext } from '../../../../context/LoadingProvider';
 
-function CreditCardLoadingModal() {
-  return (
-    <form>
-      <button type="button">100원</button>
-      <button type="button">500원</button>
-      <button type="button">1000원</button>
-      <button type="button">10000원</button>
-      <button type="submit">현금결제</button>
-    </form>
-  );
+interface Props {
+  closeModal: () => void;
+  openReceiptModal: () => void;
+}
+
+function CreditCardLoadingModal({ closeModal, openReceiptModal }: Props) {
+  const { changeIsLoading } = useContext(loadingContext);
+
+  setTimeout(() => {
+    changeIsLoading(false);
+    openReceiptModal();
+    closeModal();
+  }, 1000);
+
+  useEffect(() => {
+    changeIsLoading(true);
+  }, [changeIsLoading]);
+
+  return <div>감사합니다 고객님</div>;
 }
 
 export default CreditCardLoadingModal;

--- a/frontend/src/components/Modal/PaymentModal/PaymentSelect/PaymentSelectModalTrigger.tsx
+++ b/frontend/src/components/Modal/PaymentModal/PaymentSelect/PaymentSelectModalTrigger.tsx
@@ -31,7 +31,10 @@ function PaymentSelectModalTrigger() {
         isModalOpen={cardLoading.isModalOpen}
         closeModal={cardLoading.closeModal}
       >
-        <CreditCardLoadingModal />
+        <CreditCardLoadingModal
+          closeModal={cardLoading.closeModal}
+          openReceiptModal={receipt.openModal}
+        />
       </Modal>
       <Modal isModalOpen={cash.isModalOpen} closeModal={cash.closeModal}>
         <CashModal

--- a/frontend/src/components/Modal/hooks.ts
+++ b/frontend/src/components/Modal/hooks.ts
@@ -12,8 +12,10 @@ type eventType =
 export function useModal() {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const openModal = (event: eventType) => {
-    event.stopPropagation();
+  const openModal = (event?: eventType) => {
+    if (event) {
+      event.stopPropagation();
+    }
 
     setIsModalOpen(() => true);
   };

--- a/frontend/src/context/ContextProvider.tsx
+++ b/frontend/src/context/ContextProvider.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import AdminAuthorityProvider from './AdminAuthorityProvider';
 import CartProvider from './CartProvider';
+import LoadingProvider from './LoadingProvider';
 import StoreProvider from './StoreProvider';
 
 function ContextProvider({ children }: { children: React.ReactNode }) {
   return (
     <StoreProvider>
       <CartProvider>
-        <AdminAuthorityProvider>{children}</AdminAuthorityProvider>
+        <LoadingProvider>
+          <AdminAuthorityProvider>{children}</AdminAuthorityProvider>
+        </LoadingProvider>
       </CartProvider>
     </StoreProvider>
   );

--- a/frontend/src/context/LoadingProvider.tsx
+++ b/frontend/src/context/LoadingProvider.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useState } from 'react';
+
+interface LoadingContextType {
+  isLoading: boolean;
+  changeIsLoading: (prev: boolean) => void;
+}
+
+export const loadingContext = createContext<LoadingContextType>({
+  isLoading: false,
+  changeIsLoading: () => undefined,
+});
+
+function LoadingProvider({ children }: { children: React.ReactNode }) {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const loadingContextValue = {
+    isLoading,
+    changeIsLoading: setIsLoading,
+  };
+
+  return (
+    <loadingContext.Provider value={loadingContextValue}>
+      {children}
+    </loadingContext.Provider>
+  );
+}
+
+export default LoadingProvider;


### PR DESCRIPTION
# 📑 개요
전역 상태에 따라 로딩 스피너를 출력하는 로딩 컴포넌트를 구현한다.

# 📎 관련 이슈
#42 

# 💬 작업 내용
- 로딩 컴포넌트 전역 상태에 따라 렌더링
- 타이머에 맞춰 로딩 인디케이터 출력

# 🚧 PR 특이 사항
Closes #42 

# 🌡 실제 소요 시간
30m

# 🎁 어려웠던 점
카드 결제 컴포넌트에서 영수증 모달을 렌더링하는데 openModal 함수가 이벤트를 인자로 받는다. 하지만 카드는 아무런 이벤트를 발동시키지 않고 영수증 모달을 출력한다. 훅에서 이 부분을 처리했다.